### PR TITLE
Allow plotting multiple audio callback analyses

### DIFF
--- a/audio_budget.js
+++ b/audio_budget.js
@@ -1,68 +1,93 @@
 var m = window.wrappedJSObject.filteredMarkers;
-var budgets = new Float32Array(m.length);
-var idx_budgets = 0;
-var callbacks = new Float32Array(m.length);
-var idx_callbacks = 0;
-var cb_time = new Float32Array(m.length);
-var idx_cb_time = 0;
-var time_base = -1;
+var store = {};
+var budget_regex = /(.*)real-time budget/i;
+var callback_regex = /(.*)::DataCallback/;
+
+function get_store(name) {
+  if (!(name in store)) {
+    let obj = {};
+    obj.budgets = new Float32Array(m.length);
+    obj.idx_budgets = 0;
+    obj.callbacks = new Float32Array(m.length);
+    obj.idx_callbacks = 0;
+    obj.cb_time = {}; new Float32Array(m.length);
+    obj.idx_cb_time = 0;
+    obj.time_base = -1;
+    store[name] = obj;
+  }
+
+  return store[name];
+}
+
 for (var i = 0; i < m.length; i++) {
-  if (m[i].name.indexOf("budget") != -1) {
-    if (time_base == -1) {
-      time_base = m[i].start;
+  let match = m[i].name.match(budget_regex);
+  if (match) {
+    let name = match[1];
+    // For backwards compatibility with the budget marker name being
+    // "Real-time budget", and the only callback marker name being
+    // "AudioCallbackDriver::DataCallback".
+    name = name.trim() || "AudioCallbackDriver";
+    let obj = get_store(name);
+    if (obj.time_base == -1) {
+      obj.time_base = m[i].start;
     }
-    cb_time[idx_cb_time++] = m[i].start - time_base;
-    budgets[idx_budgets++] = m[i].end - m[i].start;
+    obj.cb_time[obj.idx_cb_time++] = m[i].start - obj.time_base;
+    obj.budgets[obj.idx_budgets++] = m[i].end - m[i].start;
     continue;
   }
-  if (m[i].name.indexOf("DataCallback") != -1) {
-    callbacks[idx_callbacks++] = m[i].end - m[i].start;
+  match = m[i].name.match(callback_regex);
+  if (match) {
+    let name = match[1];
+    let obj = get_store(name);
+    obj.callbacks[obj.idx_callbacks++] = m[i].end - m[i].start;
     continue;
   }
 }
 
-var callback_count = idx_callbacks;
-console.log(time_base, cb_time, callbacks, budgets);
+for (let key of Object.keys(store).sort()) {
+  let obj = get_store(key);
+  let callback_count = obj.idx_callbacks;
 
-var load = new Float32Array(idx_callbacks);
-for (var i = 0; i < callback_count; i++) {
-  load[i] = callbacks[i] / budgets[i];
+  let load = new Float32Array(obj.idx_callbacks);
+  for (let i = 0; i < callback_count; i++) {
+    load[i] = obj.callbacks[i] / obj.budgets[i];
+  }
+
+  let results = {
+    name: key,
+    mean: 0,
+    median: 0,
+    stddev: 0,
+    variance: 0
+  };
+
+  let copy_load = load.slice(0);
+  copy_load.sort((a, b) => a - b);
+  results.median = copy_load[Math.floor(copy_load.length / 2)];
+  let len = callback_count;
+  // Mean
+  let sum = 0;
+
+  for (let i = 0; i < len; i++) {
+    sum += load[i];
+  }
+  results.mean = sum / len;
+
+  // Variance
+  results.variance = 0;
+  for (let i = 0; i < len; i++) {
+    results.variance += Math.pow(load[i] - results.mean, 2);
+  }
+  results.variance /= len;
+
+  // Standard deviation
+  results.stddev = Math.sqrt(results.variance);
+  results.load = load;
+  results.time = obj.cb_time;
+
+  if (obj.idx_budgets != 0) {
+    plot(results);
+  }
+
+  console.log(results);
 }
-
-var results = {
-  mean:0,
-  median: 0,
-  stddev: 0,
-  variance: 0
-};
-
-
-var copy_load = load.slice(0);
-copy_load.sort((a, b) => a - b);
-results.median = copy_load[Math.floor(copy_load.length / 2)];
-var len = callback_count;
-// Mean
-var sum = 0;
-
-for (var i = 0; i < len; i++) {
-  sum += load[i];
-}
-results.mean = sum / len;
-
-// Variance
-results.variance = 0;
-for (var i = 0; i < len; i++) {
-  results.variance += Math.pow(load[i] - results.mean, 2);
-}
-results.variance /= len;
-
-// Standard deviation
-results.stddev = Math.sqrt(results.variance);
-results.load = load;
-results.time = cb_time;
-
-if (idx_budgets != 0) {
-  plot(results);
-}
-
-console.log(results);

--- a/graph.js
+++ b/graph.js
@@ -144,7 +144,7 @@ function plot(data) {
   Plotly.newPlot(plotRootHist, [trace], layoutHist);
   var title = document.createElement("h1");
   title.className = "cb-title";
-  title.innerText = "Real-time audio callback load statistical analysis";
+  title.innerText = `Real-time audio callback load statistical analysis: ${data.name}`;
   var metricsRoot = document.createElement("div");
   metricsRoot.className = "cb-metrics";
   if (!Number.isNaN(data.mean) && !Number.isNaN(data.median) &&


### PR DESCRIPTION
This will differentiate audio callbacks by their marker name. A given identifying name 'XX' needs to have markers 'XX real-time budget' and 'XX::DataCallback' for this to work as intended.

Useful when combining for instance an AudioCallbackDriver and an AudioInputSource for a multi-mic test case.